### PR TITLE
Added a workaround for spaces in the MailSubject and MailBody options

### DIFF
--- a/README.org
+++ b/README.org
@@ -95,6 +95,7 @@ mailx_sender/Mail sender: *Unset Custom.STRING
 MailDefaultDomain/Default mail domain: Unset *Custom.STRING
 PdfFilePattern/Pattern for attached file (must have multiple X): *Default Custom.STRING
 TempDirectory/Path to temporary directory: *Default Custom.STRING
+SpacePlaceholder/Space placeholder character: *Default Custom.STRING
 #+END_SRC
 
 At least the =MailFrom= needs to be configured. Values for custom strings need to be prefixed with =Custom.= when set through =lpadmin=:
@@ -106,6 +107,12 @@ At least the =MailFrom= needs to be configured. Values for custom strings need t
 Most installations also will need to set the =mailx_smtp= option for the SMTP server. A more complicated example using SMTP-AUTH is below.
 
 Only the variables prefixed with =mailx_= will be exported as the matching mailx settings. Additional mailx configuration will need to happen through a mailxrc file. If the value of =mailx_MAILRC= does not start with a slash it is assumed the configuration is relative to =CUPS_SERVERROOT= (usually /etc/cups). Generally mailrc files should be placed there.
+
+If you would like to use spaces in your =MailSubject= or =MailBody=, you will need to use a placeholder character such as "_" (the default). For example:
+
+#+BEGIN_SRC sh
+# lpadmin -p email-sample -E -o MailSubject=Custom.This_subject_will_contain_spaces -o MailBody=Custome.Here_is_your_file -o SpacePlaceholder=Custom._
+#+END_SRC
 
 **** Adding through the web interface
 After successful installation a new printer called =E-Mail Device= should be available when adding new printers:

--- a/README.org
+++ b/README.org
@@ -111,7 +111,7 @@ Only the variables prefixed with =mailx_= will be exported as the matching mailx
 If you would like to use spaces in your =MailSubject= or =MailBody=, you will need to use a placeholder character such as "_" (the default). For example:
 
 #+BEGIN_SRC sh
-# lpadmin -p email-sample -E -o MailSubject=Custom.This_subject_will_contain_spaces -o MailBody=Custome.Here_is_your_file -o SpacePlaceholder=Custom._
+# lpadmin -p email-sample -E -o MailSubject=Custom.This_subject_will_contain_spaces -o MailBody=Custom.Here_is_your_file -o SpacePlaceholder=Custom._
 #+END_SRC
 
 **** Adding through the web interface

--- a/email
+++ b/email
@@ -31,7 +31,8 @@ config_vars="Mailx
         mailx_replyto
         mailx_sender
         TempDirectory
-        PdfFilePattern"
+        PdfFilePattern
+        SpacePlaceholder"
 
 # Variables set through the user when printing. Via lpr a user can set
 # arbitrary options. This list limits it to options exposed via the user
@@ -40,7 +41,9 @@ config_vars="Mailx
 config_user_vars="MailSubject
         MailTo
         MailFrom
-        MailBody"
+        MailBody
+        PdfFilePattern
+        SpacePlaceholder"
 
 echo "DEBUG:email backend call arguments $@" 1>&2
 # when called without any arguments CUPS expects us to print a backend
@@ -120,6 +123,10 @@ for _option in $5; do
 
     if [ "$_opt_name" == "job-billing" ]; then
         export BillingInfo="$_opt_value"
+    elif [ "$_opt_name" == "MailSubject" ]; then
+        export MailSubject=$(tr "$SpacePlaceholder" " " <<< "${_opt_value#Custom.}")
+    elif [ "$_opt_name" == "MailBody" ]; then
+        export MailBody=$(tr "$SpacePlaceholder" " " <<< "${_opt_value#Custom.}")
     elif [[ "$config_user_vars" == *$_opt_name* ]]; then
         # Some UI dialogs include all user overridable settings, even if
         # they are at defaults. They also add the (technically correct)

--- a/email.ppd
+++ b/email.ppd
@@ -181,6 +181,15 @@
 *CustomTempDirectory True: "<</cupsString1 3 -1 roll>>setpagedevice"
 *ParamCustomTempDirectory: 1 string 0 50
 
+*% configuration for the space character placeholder in MailSubject or MailBody
+*OpenUI *SpacePlaceholder/Space placeholder character: PickOne
+*DefaultSpacePlaceholder: Default
+*SpacePlaceholder Default/Default character: "_"
+*CloseUI: *SpacePlaceholder
+
+*CustomSpacePlaceholder True: "<</cupsString1 3 -1 roll>>setpagedevice"
+*ParamCustomSpacePlaceholder: 1 string 0 1
+
 *CloseGroup: InstallableOptions
 
 *DefaultFont: Courier


### PR DESCRIPTION
Since it seems CUPS (at least on Ubuntu) is doing some [pretty gnarly things with options containing spaces](https://github.com/aardsoft/cups-email/issues/3), I have added this workaround. The code isn't the most elegant, I'm afraid, but it gets the job done.