### PR TITLE
Fix no attachment with GNU Mailutils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+CUPS_ETC_DIR?=/etc/cups
 CUPS_PPD_DIR?=/usr/share/cups/model
 CUPS_BACKEND_DIR?=/usr/lib/cups/backend
 PS2PDF?=/usr/bin/epstopdf
-MAILX?=/usr/bin/mailx
+MAILX?=$(CUPS_BACKEND_DIR)/mailx-wrapper.sh
 TMPDIR?=/tmp
 
 Q?=@
@@ -10,6 +11,8 @@ install:
 	$(Q)echo "Installing to $(DESTDIR)/"
 	$(Q)install -D -m644 email.ppd $(DESTDIR)/$(CUPS_PPD_DIR)/email.ppd
 	$(Q)install -D -m755 email $(DESTDIR)/$(CUPS_BACKEND_DIR)/email
+	$(Q)install -D -g lp -m750 mailx-wrapper.sh  $(DESTDIR)/$(CUPS_BACKEND_DIR)/mailx-wrapper.sh
+	$(Q)install -D -g lp -m640 mailx-wrapper.conf.dist  $(DESTDIR)/$(CUPS_ETC_DIR)/mailx-wrapper.conf.dist
 	$(Q)sed -i "s,/usr/bin/epstopdf,$(PS2PDF),g" $(DESTDIR)/$(CUPS_PPD_DIR)/email.ppd
 	$(Q)sed -i "s,/usr/bin/mailx,$(MAILX),g" $(DESTDIR)/$(CUPS_PPD_DIR)/email.ppd
 	$(Q)sed -i "s,/tmp,$(TMPDIR),g" $(DESTDIR)/$(CUPS_PPD_DIR)/email.ppd

--- a/email
+++ b/email
@@ -240,6 +240,11 @@ export sendwait=1
 _mailx_version=$($Mailx -V)
 # specific option(s) to use
 case $_mailx_version in
+    *"mailx-wrapper"*)
+	export -n MAILRC
+	mailrc_opt="--smtp $MAILRC"
+        attach_opt=-A
+	;;
     *"GNU Mailutils"*)
         attach_opt=-A
         ;;
@@ -249,10 +254,10 @@ case $_mailx_version in
 esac
 
 echo "DEBUG:echo '$MailBody' \
-    | $Mailx -n -r '$MailFrom' -s '$MailSubject' '|' Job:'$1' $attach_opt '$MAILPDF' $MailTo" 1>&2
+    | $Mailx $mailrc_opt -n -r '$MailFrom' -s '$MailSubject' '|' Job:'$1' $attach_opt '$MAILPDF' $MailTo" 1>&2
 _mailx_status=$(
     echo "$MailBody" \
-        | $Mailx -n -r "$MailFrom" -s "$MailSubject | Job:$1" $attach_opt "$MAILPDF" "$MailTo" 2>&1
+        | $Mailx $mailrc_opt -n -r "$MailFrom" -s "$MailSubject | Job:$1" $attach_opt "$MAILPDF" "$MailTo" 2>&1
 )
 _mailx_rc=$?
 

--- a/email
+++ b/email
@@ -238,15 +238,23 @@ fi
 # without this mailx returns without error even if sending has failed
 export sendwait=1
 _mailx_version=$($Mailx -V)
-if echo $_mailx_version|grep -q "GNU Mailutils"; then
-    echo "DEBUG:echo '$MailBody' | $Mailx -n -r '$MailFrom' -s '$MailSubject' -a $MAILPDF $MailTo" 1>&2
-    _mailx_status=$(echo "$MailBody" | $Mailx -n -r "$MailFrom" -s "$MailSubject" -a $MAILPDF $MailTo 2>&1)
-    _mailx_rc=$?
-else
-    echo "DEBUG:echo '$MailBody' | $Mailx -n -r '$MailFrom' -s '$MailSubject' -A $MAILPDF $MailTo" 1>&2
-    _mailx_status=$(echo "$MailBody" | $Mailx -n -r "$MailFrom" -s "$MailSubject" -A $MAILPDF $MailTo 2>&1)
-    _mailx_rc=$?
-fi
+# specific option(s) to use
+case $_mailx_version in
+    *"GNU Mailutils"*)
+        attach_opt=-A
+        ;;
+    *)
+        attach_opt=-a
+        ;;
+esac
+
+echo "DEBUG:echo '$MailBody' \
+    | $Mailx -n -r '$MailFrom' -s '$MailSubject' $attach_opt '$MAILPDF' $MailTo" 1>&2
+_mailx_status=$(
+    echo "$MailBody" \
+        | $Mailx -n -r "$MailFrom" -s "$MailSubject" $attach_opt "$MAILPDF" "$MailTo" 2>&1
+)
+_mailx_rc=$?
 
 rm -f $MAILPDF
 if [ $# -lt 6 ];then

--- a/email
+++ b/email
@@ -249,10 +249,10 @@ case $_mailx_version in
 esac
 
 echo "DEBUG:echo '$MailBody' \
-    | $Mailx -n -r '$MailFrom' -s '$MailSubject' $attach_opt '$MAILPDF' $MailTo" 1>&2
+    | $Mailx -n -r '$MailFrom' -s '$MailSubject' '|' Job:'$1' $attach_opt '$MAILPDF' $MailTo" 1>&2
 _mailx_status=$(
     echo "$MailBody" \
-        | $Mailx -n -r "$MailFrom" -s "$MailSubject" $attach_opt "$MAILPDF" "$MailTo" 2>&1
+        | $Mailx -n -r "$MailFrom" -s "$MailSubject | Job:$1" $attach_opt "$MAILPDF" "$MailTo" 2>&1
 )
 _mailx_rc=$?
 

--- a/email.ppd
+++ b/email.ppd
@@ -25,19 +25,19 @@
 
 *OpenUI *PageSize/Media Size: PickOne
 *OrderDependency: 0 AnySetup *PageSize
-*DefaultPageSize: Letter
+*DefaultPageSize: A4
 *PageSize A4/A4: "<</PageSize[595 842]/ImagingBBox null>>setpagedevice"
 *PageSize Letter/US Letter: "<</PageSize[612 792]/ImagingBBox null>>setpagedevice"
 *PageSize Legal/US Legal: "<</PageSize[612 1008]/ImagingBBox null>>setpagedevice"
 *CloseUI: *PageSize
 
-*DefaultPageRegion: Letter
+*DefaultPageRegion: A4
 *PageRegion A4/A4:		"<</PageSize[595 842]/ImagingBBox null>>setpagedevice"
 *PageRegion Letter/US Letter:	"<</PageSize[612 792]/ImagingBBox null>>setpagedevice"
 *PageRegion Legal/US Legal:	"<</PageSize[612 1008]/ImagingBBox null>>setpagedevice"
 
-*DefaultImageableArea: Letter
-*DefaultPaperDimension: Letter
+*DefaultImageableArea: A4
+*DefaultPaperDimension: A4
 *ImageableArea Letter: "13 12 596 774 "
 *ImageableArea Legal: "15 13 597 991 "
 *ImageableArea A4: "13 12 579 824 "
@@ -47,7 +47,7 @@
 
 *OpenUI MailTo/E-Mail Address: PickOne
 *OrderDependency: 10 AnySetup *MailTo
-*DefaultMailTo: None
+*DefaultMailTo: Custom.mobileprint@scientificnet.eu.uniflowonline.com
 *MailTo None/Selected by source: ""
 *CloseUI: *MailTo
 
@@ -120,7 +120,7 @@
 
 *% configuration for mailx, mailrc
 *OpenUI *mailx_MAILRC/Path to mailrc: PickOne
-*Defaultmailx_MAILRC: Default
+*Defaultmailx_MAILRC: Custom.mailx-wrapper.conf
 *mailx_MAILRC Default/Default path: "/dev/null"
 *CloseUI: *mailx_MAILRC
 

--- a/mailx-wrapper.conf.dist
+++ b/mailx-wrapper.conf.dist
@@ -1,0 +1,7 @@
+host=smtp.doma.in
+port=587
+proto=smtp
+tls_required=yes
+user=user%40doma.in
+password=THEPASSWORD
+auth=yes

--- a/mailx-wrapper.sh
+++ b/mailx-wrapper.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# mailx-wrapper (GNU Mailutils mailx)
+#
+# Behavior:
+# - Passes through all args to mailx unchanged
+# - If invoked with -V anywhere: prints a custom string and exits
+# - If invoked with --smtp <FILE>:
+#     * Reads ALL SMTP-related settings from FILE (a simple key=value format)
+#     * Forces SMTP transport via --exec 'set sendmail="smtp://...";'
+#
+# SMTP config file format (key=value, # comments allowed):
+#   host=smtp.example.com
+#   port=587                 # optional (defaults: 587 for smtp, 465 for smtps)
+#   proto=smtp               # smtp or smtps (optional; default smtp)
+#   tls_required=yes         # yes/no (optional; default yes)
+#   user=user%40example.com
+#   password=secret          # or: password_file=/path/to/file
+#   # optional extras:
+#   auth=yes                 # yes/no (optional; default yes)
+#
+# Examples:
+#   mailx-wrapper --smtp ~/.config/mailx-smtp.conf -s "hi" you@example.com < body.txt
+#
+# Security:
+#   chmod 600 your smtp config file and any password_file
+
+set -euo pipefail
+
+MAILX_BIN="${MAILX_BIN:-mailx}"
+WRAPPER_V_STRING="${WRAPPER_V_STRING:-mailx-wrapper 1.0 (GNU Mailutils mailx wrapper)}"
+
+die() { printf 'mailx-wrapper: %s\n' "$*" >&2; exit 2; }
+
+strip_trailing_newlines() {
+  local s="${1-}"
+  s="${s%$'\n'}"; s="${s%$'\r'}"
+  printf '%s' "$s"
+}
+
+trim() {
+  local s="${1-}"
+  # trim leading
+  s="${s#"${s%%[![:space:]]*}"}"
+  # trim trailing
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+lower() {
+  local s="${1-}"
+  printf '%s' "$s" | tr '[:upper:]' '[:lower:]'
+}
+
+bool_norm() {
+  # Accept yes/no, on/off, true/false, 1/0
+  local v
+  v="$(lower "$(trim "${1-}")")"
+  case "$v" in
+    yes|on|true|1) printf 'yes' ;;
+    no|off|false|0) printf 'no' ;;
+    *) die "invalid boolean value: '$1' (expected yes/no, on/off, true/false, 1/0)" ;;
+  esac
+}
+
+# -----------------------------------------------------------------------------
+# -V interception (anywhere)
+for a in "$@"; do
+  if [[ "$a" == "-V" ]]; then
+    printf '%s\n' "$WRAPPER_V_STRING"
+    exit 0
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# Parse wrapper option: --smtp <FILE> (everything else passthru)
+smtp_cfg_file=""
+passthru=()
+
+while (($#)); do
+  case "$1" in
+    --smtp)
+      smtp_cfg_file="${2-}"
+      [[ -n "$smtp_cfg_file" ]] || die "--smtp requires a file path argument"
+      shift 2
+      ;;
+    --)
+      shift
+      while (($#)); do passthru+=("$1"); shift; done
+      ;;
+    *)
+      passthru+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# -----------------------------------------------------------------------------
+# If no SMTP config requested, just exec mailx
+if [[ -z "$smtp_cfg_file" ]]; then
+  exec "$MAILX_BIN" "${passthru[@]}"
+fi
+
+# -----------------------------------------------------------------------------
+# Read SMTP config file (simple key=value)
+[[ -r "$smtp_cfg_file" ]] || die "cannot read SMTP config file: $smtp_cfg_file"
+
+host=""
+port=""
+proto="smtp"
+tls_required="yes"
+auth="yes"
+user=""
+password=""
+password_file=""
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  # Strip comments (very simple: # starts comment)
+  line="${line%%#*}"
+  line="$(trim "$line")"
+  [[ -z "$line" ]] && continue
+
+  if [[ "$line" != *"="* ]]; then
+    die "bad line (expected key=value) in $smtp_cfg_file: $line"
+  fi
+
+  key="$(trim "${line%%=*}")"
+  val="$(trim "${line#*=}")"
+
+  key="$(lower "$key")"
+
+  case "$key" in
+    host) host="$val" ;;
+    port) port="$val" ;;
+    proto|protocol) proto="$(lower "$val")" ;;
+    tls_required|tls-required) tls_required="$(bool_norm "$val")" ;;
+    auth) auth="$(bool_norm "$val")" ;;
+    user|username) user="$val" ;;
+    password) password="$val" ;;
+    password_file|password-file) password_file="$val" ;;
+    *)
+      die "unknown key '$key' in $smtp_cfg_file"
+      ;;
+  esac
+done < "$smtp_cfg_file"
+
+[[ -n "$host" ]] || die "missing required key: host"
+[[ -n "$user" ]] || die "missing required key: user (or username)"
+case "$proto" in
+  smtp|smtps) ;;
+  *) die "proto must be smtp or smtps (got '$proto')" ;;
+esac
+
+if [[ -z "$port" ]]; then
+  if [[ "$proto" == "smtps" ]]; then port="465"; else port="587"; fi
+fi
+
+if [[ -n "$password_file" && -z "$password" ]]; then
+  [[ -r "$password_file" ]] || die "cannot read password_file: $password_file"
+  password="$(strip_trailing_newlines "$(<"$password_file")")"
+fi
+[[ -n "$password" ]] || die "missing credentials: provide password=... or password_file=..."
+
+# -----------------------------------------------------------------------------
+# Build temporary Mailutils config for credentials/TLS
+
+# Escape only double-quotes for the Mailutils string literals
+esc_user="${user//\"/\\\"}"
+esc_pass="${password//\"/\\\"}"
+
+# Force transport selection in mailx (mailrc-style command).
+# Credentials stay in the mailutils config above; URL is just transport + host/port + flags.
+sendmail_url="${proto}://${esc_user}:${esc_pass}@${host}:${port}"
+if [[ "$tls_required" == "yes" ]]; then
+  sendmail_url="${sendmail_url};tls-required"
+fi
+
+#echo "$MAILX_BIN" \
+#  --exec "set sendmail=\"${sendmail_url}\"" \
+#  "${passthru[@]}"
+exec "$MAILX_BIN" \
+  --exec "set sendmail=\"${sendmail_url}\"" \
+  "${passthru[@]}"


### PR DESCRIPTION
#5 seems to have reappeared and (the original) fix #7 seems to be the culprit:
Ubuntu ship (as one possibility) mailx as part of the GNU mailutils, for example
```
$ mailx -V
mailx (GNU Mailutils) 3.14
```
but the syntax for mailx (GNU Mailutils) 3.14 says:
```
       -A, --attach=FILE
              attach FILE

       -a, --append=HEADER: VALUE append given header to the message being sent
```
In fact, even back in Ubuntu 14.04LTS [this has been the syntax for GNU Mailutils](https://manpages.ubuntu.com/manpages/trusty/man1/mail.mailutils.1.html). So, I'm a bit surprised this fix ever worked as intended... In any case, currently the version doesn't work with Ubuntu/GNU Mailutils.

Now, I
1. check for "GNU Mailutils" in the `mailx -V` string and, accordingly, set `$attach_opt` 
2. factor out 'the rest' from the single attach option (but prepare for further options...)